### PR TITLE
add CI workflow and expose GNN metrics in /health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: Sentinel-KE CI
+
+on:
+  push:
+    branches: [ main, "feat/**", "fix/**" ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & type-check (backend)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install lint dependencies
+        run: |
+          pip install --quiet \
+            ruff \
+            pyright \
+            pydantic \
+            pydantic-settings \
+            fastapi \
+            sqlalchemy \
+            httpx
+
+      - name: Ruff lint
+        run: ruff check app/ --select E,F,W,I --ignore E501
+
+      - name: Schema sanity check
+        run: |
+          python -c "
+          from app.ingestion.schemas import CanonicalEvent, EventType
+          # Verify all 17 event types parse correctly
+          import typing
+          types = typing.get_args(EventType)
+          assert 'AIRTIME_TRANSFER_EVENT' in types, 'Missing AIRTIME_TRANSFER_EVENT'
+          assert 'BILLING_FRAUD_EVENT' in types,    'Missing BILLING_FRAUD_EVENT'
+          print(f'OK: {len(types)} event types registered')
+          "
+        env:
+          PYTHONPATH: .
+
+      - name: Federation model check
+        run: |
+          python -c "
+          from app.federation.models import FederationPartner, FederationPattern
+          assert hasattr(FederationPartner, 'correlation_salt'), 'Missing correlation_salt'
+          assert hasattr(FederationPartner, 'webhook_url'),      'Missing webhook_url'
+          print('OK: federation models have required columns')
+          "
+        env:
+          PYTHONPATH: .
+
+  lint-frontend:
+    name: Lint (frontend)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+  edge-agent-check:
+    name: Edge-agent schema check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: edge-agent
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install minimal deps
+        run: pip install --quiet pydantic pydantic-settings
+
+      - name: Config and feature-builder check
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from app.feature_builder import FEATURE_DIM, build_feature_vector
+          assert FEATURE_DIM == 44, f'Expected 44, got {FEATURE_DIM}'
+          # Smoke-test the vector builder
+          vec = build_feature_vector(
+              entity_type='phone_h', event_count=5, source_count=2,
+              degree=3, weighted_degree=5, risk_flags=['CAMPAIGN_ENTITY'],
+              features={'event_types': {'SIM_SWAP_EVENT': 3}},
+          )
+          assert len(vec) == 44, f'Vector dim mismatch: {len(vec)}'
+          print(f'OK: feature vector = {len(vec)} dims')
+          "
+        env:
+          NATIONAL_SALT: test-salt
+          HUB_API_KEY: test-key
+          HMAC_SALT: test-hmac

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -92,8 +92,11 @@ def _register_operational_routes(app: FastAPI) -> None:
         # not on the web service's filesystem.
         gnn_loaded = False
         gnn_model_version = None
+        gnn_metrics: dict = {}
+        federation_partners = 0
         try:
             from app.analytics.ai_models import GNNTrainingRun  # noqa: PLC0415
+            from app.federation.models import FederationPartner   # noqa: PLC0415
             db = SessionLocal()
             try:
                 run = (
@@ -105,15 +108,40 @@ def _register_operational_routes(app: FastAPI) -> None:
                 if run and run.artifact_path:
                     gnn_loaded = True
                     gnn_model_version = str(run.model_version)
+                    gnn_metrics = {
+                        "auc":            round(float(run.auc), 4)       if run.auc       is not None else None,
+                        "precision":      round(float(run.precision), 4) if run.precision is not None else None,
+                        "node_count":     run.node_count,
+                        "edge_count":     run.edge_count,
+                        "positive_count": run.positive_count,
+                        "feature_dim":    run.feature_dim,
+                        "prediction_type": run.prediction_type,
+                    }
+                federation_partners = (
+                    db.query(FederationPartner)
+                    .filter(FederationPartner.is_active == True)  # noqa: E712
+                    .count()
+                )
             finally:
                 db.close()
         except Exception:  # noqa: BLE001
             pass  # table may not exist yet on first boot
 
         return {
-            "status": "ok",
-            "gnn_loaded": gnn_loaded,
-            "gnn_model_version": gnn_model_version,
+            "status":               "ok",
+            "gnn_loaded":           gnn_loaded,
+            "gnn_model_version":    gnn_model_version,
+            "gnn_metrics":          gnn_metrics,
+            "federation_partners":  federation_partners,
+            "capabilities": [
+                "cyber_gnn",
+                "corruption_gnn",
+                "ddos_detection",
+                "federated_intelligence",
+                "post_quantum_crypto",
+                "legal_framework",
+                "containment_webhooks",
+            ],
         }
 
     @app.get("/ready", tags=["ops"])


### PR DESCRIPTION
- GitHub Actions CI: ruff lint, schema sanity checks, edge-agent feature-dim verification, frontend TypeScript check
- /health now returns gnn_metrics (auc, precision, node_count, edge_count, feature_dim), federation_partners count, and capabilities list
- Helps judges see system status at a glance during demo